### PR TITLE
$refresh() does not work twice in a closure

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,10 @@
     {
       "name": "Daniel Kuck-Alvarez",
       "email": "dkuck@thatsus.com"
+    },
+    {
+      "name": "Potsky",
+      "email": "potsky@me.com"
     }
   ],
   "require": {
@@ -21,7 +25,8 @@
   },
   "require-dev": {
     "laravel/framework": "5.1.*",
-    "php-mock/php-mock-mockery": "^1.1"
+    "php-mock/php-mock-mockery": "^1.1",
+    "phpunit/phpunit": "~5.7"
   },
   "autoload": {
     "psr-4": {

--- a/src/RedLock.php
+++ b/src/RedLock.php
@@ -113,8 +113,9 @@ class RedLock
         if (!$lock) {
             return false;
         }
-        $refresh = function () use ($lock) {
-            if (!$this->refreshLock($lock)) {
+        $refresh = function () use (&$lock) {
+            $lock = $this->refreshLock($lock);
+            if (!$lock) {
                 throw new Exceptions\ClosureRefreshException();
             }
         };
@@ -123,7 +124,9 @@ class RedLock
         } catch (Exceptions\ClosureRefreshException $e) {
             return false;
         } finally {
-            $this->unlock($lock);
+            if (is_array($lock)) {
+                $this->unlock($lock);
+            }
         }
         return $result;
     }

--- a/tests/RedLockTest.php
+++ b/tests/RedLockTest.php
@@ -162,7 +162,7 @@ class RedLockTest extends TestCase
             ->andReturn(true, false, false, false);
         $predis->shouldReceive('eval')
             ->with(Mockery::any(), 1, 'XYZ', Mockery::any())
-            ->times(5)
+            ->times(4)
             ->andReturn(true);
         App::instance(Redis::class, $predis);
 


### PR DESCRIPTION
This commit :

- adds phpunit as a dependency to test the package
- fix the ugly test where the eval and set functions where not called the same time. It hided the problem
- when refreshing the lock in a closure called by a closure, we need to update the refreshed lock because the token will change the first time we call the `refresh()` function. Then the second time we call `refresh()`, the Redis script with `KEYS[1]` and `ARGS[1]` will fail because the token has changed and it was not saved.

Unfortunately, there is no way to add a test for this because we need to mock the Redis script and there is no interest to use a mockery for this.