### PR TITLE
Fix lock time override

### DIFF
--- a/src/Traits/QueueWithoutOverlap.php
+++ b/src/Traits/QueueWithoutOverlap.php
@@ -9,7 +9,6 @@ use ThatsUs\RedLock\Exceptions\QueueWithoutOverlapRefreshException;
 trait QueueWithoutOverlap
 {
     protected $lock;
-    protected $lock_time = 300; // in seconds; 5 minutes default
 
     /**
      * Put this job on that queue. Or don't 
@@ -36,7 +35,8 @@ trait QueueWithoutOverlap
      */
     protected function acquireLock(array $lock = [])
     {
-        $this->lock = RedLock::lock($lock['resource'] ?? $this->getLockKey(), $this->lock_time * 1000);
+        $lock_time = isset($this->lock_time) ? $this->lock_time : 300; // in seconds; 5 minutes default
+        $this->lock = RedLock::lock($lock['resource'] ?? $this->getLockKey(), $lock_time * 1000);
         return (bool)$this->lock;
     }
 

--- a/tests/QueueWithoutOverlapTest.php
+++ b/tests/QueueWithoutOverlapTest.php
@@ -21,11 +21,11 @@ class QueueWithoutOverlapTest extends TestCase
         $queue->shouldReceive('push')->with($job)->once();
 
         RedLock::shouldReceive('lock')
-            ->with("ThatsUs\RedLock\Traits\QueueWithoutOverlapJob:::300", 300000)
+            ->with("ThatsUs\RedLock\Traits\QueueWithoutOverlapJob::1000:", 1000000)
             ->twice()
-            ->andReturn(['resource' => 'ThatsUs\RedLock\Traits\QueueWithoutOverlapJob:::300']);
+            ->andReturn(['resource' => 'ThatsUs\RedLock\Traits\QueueWithoutOverlapJob::1000:']);
         RedLock::shouldReceive('unlock')
-            ->with(['resource' => 'ThatsUs\RedLock\Traits\QueueWithoutOverlapJob:::300'])
+            ->with(['resource' => 'ThatsUs\RedLock\Traits\QueueWithoutOverlapJob::1000:'])
             ->twice()
             ->andReturn(true);
 
@@ -43,7 +43,7 @@ class QueueWithoutOverlapTest extends TestCase
         $queue = Mockery::mock();
 
         RedLock::shouldReceive('lock')
-            ->with("ThatsUs\RedLock\Traits\QueueWithoutOverlapJob:::300", 300000)
+            ->with("ThatsUs\RedLock\Traits\QueueWithoutOverlapJob::1000:", 1000000)
             ->once()
             ->andReturn(false);
 
@@ -60,14 +60,14 @@ class QueueWithoutOverlapTest extends TestCase
         $queue->shouldReceive('push')->with($job)->once();
 
         RedLock::shouldReceive('lock')
-            ->with("ThatsUs\RedLock\Traits\QueueWithoutOverlapJob:::300", 300000)
+            ->with("ThatsUs\RedLock\Traits\QueueWithoutOverlapJob::1000:", 1000000)
             ->twice()
             ->andReturn(
-                ['resource' => 'ThatsUs\RedLock\Traits\QueueWithoutOverlapJob:::300'],
+                ['resource' => 'ThatsUs\RedLock\Traits\QueueWithoutOverlapJob::1000:'],
                 false
             );
         RedLock::shouldReceive('unlock')
-            ->with(['resource' => 'ThatsUs\RedLock\Traits\QueueWithoutOverlapJob:::300'])
+            ->with(['resource' => 'ThatsUs\RedLock\Traits\QueueWithoutOverlapJob::1000:'])
             ->once()
             ->andReturn(true);
 

--- a/tests/QueueWithoutOverlapTest.php
+++ b/tests/QueueWithoutOverlapTest.php
@@ -77,4 +77,27 @@ class QueueWithoutOverlapTest extends TestCase
 
         $job->handle();
     }
+
+    public function testAllOfItDefaultLockTime()
+    {
+        $job = new QueueWithoutOverlapJobDefaultLockTime();
+
+        $queue = Mockery::mock();
+        $queue->shouldReceive('push')->with($job)->once();
+
+        RedLock::shouldReceive('lock')
+            ->with("ThatsUs\RedLock\Traits\QueueWithoutOverlapJobDefaultLockTime::", 300000)
+            ->twice()
+            ->andReturn(['resource' => "ThatsUs\RedLock\Traits\QueueWithoutOverlapJobDefaultLockTime::"]);
+        RedLock::shouldReceive('unlock')
+            ->with(['resource' => "ThatsUs\RedLock\Traits\QueueWithoutOverlapJobDefaultLockTime::"])
+            ->twice()
+            ->andReturn(true);
+
+        $job->queue($queue, $job);
+
+        $job->handle();
+
+        $this->assertTrue($job->ran);
+    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -17,17 +17,6 @@ class TestCase extends Base
 
         $app->make(Kernel::class)->bootstrap();
 
-        //$this->setTestEnvironment();
-
-        // don't want these kinds of error notifications
-        error_reporting(
-            E_ALL 
-            & ~ E_NOTICE 
-            //& ~ E_WARNING 
-            //& ~ E_DEPRECATED 
-            //& ~ E_STRICT
-        );
-
         return $app;
     }
 }

--- a/tests/fixtures/QueueWithoutOverlapJob.php
+++ b/tests/fixtures/QueueWithoutOverlapJob.php
@@ -17,6 +17,7 @@ class QueueWithoutOverlapJob
     use QueueWithoutOverlap;
 
     public $ran = false;
+    protected $lock_time = 1000;
 
     public function handleSync()
     {

--- a/tests/fixtures/QueueWithoutOverlapJobDefaultLockTime.php
+++ b/tests/fixtures/QueueWithoutOverlapJobDefaultLockTime.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace ThatsUs\RedLock\Traits;
+
+/*
+|--------------------------------------------------------------------------
+| QueueWithoutOverlapJob
+|--------------------------------------------------------------------------
+|
+| This class is for testing the WithoutOverlap trait. It just uses the 
+| trait and that's all.
+|
+*/
+
+class QueueWithoutOverlapJobDefaultLockTime
+{
+    use QueueWithoutOverlap;
+
+    public $ran = false;
+
+    public function handleSync()
+    {
+        $this->refreshLock();
+        $this->ran = true;
+    }
+}

--- a/tests/fixtures/QueueWithoutOverlapJobDefaultLockTime.php
+++ b/tests/fixtures/QueueWithoutOverlapJobDefaultLockTime.php
@@ -8,7 +8,7 @@ namespace ThatsUs\RedLock\Traits;
 |--------------------------------------------------------------------------
 |
 | This class is for testing the WithoutOverlap trait. It just uses the 
-| trait and that's all.
+| trait and that's all. This time without a $lock_time specified
 |
 */
 


### PR DESCRIPTION
Fixes issue reported here: https://github.com/thatsus/laravel-redlock/commit/3e652194cf0d3d359efc386acfb5b877c24dddf3

When you specified $lock_time on a Job that uses `QueueWithoutOverlap`, you would get this exception:

```
[Symfony\Component\Debug\Exception\FatalErrorException]
  ThatsUs\RedLock\Traits\QueueWithoutOverlapJob and ThatsUs\RedLock\Traits\Qu
  eueWithoutOverlap define the same property ($lock_time) in the composition
  of ThatsUs\RedLock\Traits\QueueWithoutOverlapJob. However, the definition d
  iffers and is considered incompatible. Class was composed
```

Now it's fixed and tested:

```
phpunit
PHPUnit 5.7.16 by Sebastian Bergmann and contributors.

................                                                  16 / 16 (100%)

Time: 975 ms, Memory: 14.00MB

OK (16 tests, 15 assertions)
```