### PR TITLE
Support for laravel 5.4 and 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,14 +19,14 @@
   ],
   "require": {
     "php": ">=5.4.0",
-    "illuminate/support": "^5.0,<5.5",
-    "illuminate/console": "^5.0,<5.5",
+    "illuminate/support": "^5.0,<5.6",
+    "illuminate/console": "^5.0,<5.6",
     "predis/predis": "^1.1"
   },
   "require-dev": {
-    "laravel/framework": "5.1.*",
+    "laravel/framework": "5.4.*||5.5.*",
     "php-mock/php-mock-mockery": "^1.1",
-    "phpunit/phpunit": "~5.7"
+    "phpunit/phpunit": "~5.7||~6.0"
   },
   "autoload": {
     "psr-4": {

--- a/src/RedLock.php
+++ b/src/RedLock.php
@@ -75,7 +75,7 @@ class RedLock
         if (empty($this->instances)) {
             foreach ($this->servers as $server) {
                 //list($host, $port, $database) = $server;
-                $redis = App::make(Redis::class, [$server]);
+                $redis = App::makeWith(Redis::class, ['parameters' => $server]);
                 //$redis->connect($host, $port, $timeout);
                 $this->instances[] = $redis;
             }


### PR DESCRIPTION
Loosened the constraints.
Also, I updated the App::make() to App::makeWith() because laravel 5.4 and 5.5 doesn't support make().
If we don't update the make() to makeWith(), it will work in localhost(127.0.0.1) but will crash when we are on other servers like on production.
The reason is that make will still create the instance but will be unable to pass the $servers parameters which will force  redis client to use $default parameters i.e (127.0.0.1 etc)