### PR TITLE
Update laravel composer to < 5.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
   ],
   "require": {
     "php": ">=5.4.0",
-    "illuminate/support": "^5.0,<5.5",
-    "illuminate/console": "^5.0,<5.5",
+    "illuminate/support": "^5.0,<5.6",
+    "illuminate/console": "^5.0,<5.6",
     "predis/predis": "^1.1"
   },
   "require-dev": {


### PR DESCRIPTION
Currently laravel redlock will not install with laravel 5.5 as there is an error in the composer.json