### PR TITLE
use --dev in tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,13 +48,13 @@
   "scripts": {
     "test": [
       "rm vendor -rf; rm composer.lock; echo 1",
-      "composer require orchestra/testbench 3.4",
+      "composer require --dev orchestra/testbench 3.4",
       "phpunit | tee phpunit.4.log",
       "rm vendor -rf; rm composer.lock; echo 1",
-      "composer require orchestra/testbench 3.3",
+      "composer require --dev orchestra/testbench 3.3",
       "phpunit | tee phpunit.3.log",
       "rm vendor -rf; rm composer.lock; echo 1",
-      "composer require orchestra/testbench 3.2",
+      "composer require --dev orchestra/testbench 3.2",
       "phpunit | tee phpunit.2.log",
       "cat phpunit.*.log"
     ]


### PR DESCRIPTION
I used this method in my ScoreLabs/laravel-event-fake project and it caused me to accidentally commit orchestra/testbench as a dependency instead of a dev dependency. This removes the risk for that error.